### PR TITLE
Fix update scheduler

### DIFF
--- a/.github/workflows/arfifact.yaml
+++ b/.github/workflows/arfifact.yaml
@@ -48,10 +48,18 @@ jobs:
           echo "Building image with $(make version) tag"
           echo "TAG=$(make version)" >> $GITHUB_ENV
       
+      - name: Ensure the tag does not exist
+        id: check-tag
+        shell: bash
+        run: |
+          echo "Checking if the tag already exists"
+          TAG_EXISTS=$(git tag -l "${{ env.TAG }}")
+          echo "TAG_EXISTS=$TAG_EXISTS" >> $GITHUB_ENV
+
       - name: Build and push Docker image
         id: push
         uses: docker/build-push-action@v6
-        if: steps.tag.outcome == 'success' && steps.auth-gar.outcome == 'success'
+        if: steps.tag.outcome == 'success' && steps.auth-gar.outcome == 'success' && steps.check-tag.outputs.TAG_EXISTS == ''
         with:
           platforms: linux/amd64
           push: true

--- a/.github/workflows/artifact.yaml
+++ b/.github/workflows/artifact.yaml
@@ -59,7 +59,7 @@ jobs:
       - name: Build and push Docker image
         id: push
         uses: docker/build-push-action@v6
-        if: steps.tag.outcome == 'success' && steps.auth-gar.outcome == 'success' && steps.check-tag.outputs.TAG_EXISTS == ''
+        if: steps.tag.outcome == 'success' && steps.auth-gar.outcome == 'success' && env.TAG_EXISTS == ''
         with:
           platforms: linux/amd64
           push: true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -31,6 +31,7 @@ jobs:
           echo "LATEST_VERSION=${LATEST_VERSION}" >> $GITHUB_ENV
           echo "Latest version is $VERSION"
           echo "Getting the current version from the Makefile"
+          CURRENT_VERSION=$(make version)
           echo "CURRENT_VERSION=${CURRENT_VERSION}" >> $GITHUB_ENV
           echo "Current version is $CURRENT_VERSION"
 


### PR DESCRIPTION
This PR attempts to fix:

1. Make sure that changes to the repository that do not reflect the update of the docker image tag, do not trigger the release
2. Ensure that the version is inferred when setting the PR for version update.